### PR TITLE
build: add action to publish to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - release
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,6 @@ name: Publish to PyPI
 on:
   release:
     types: [created]
-  # TODO: remove this
-  push:
-    branches:
-      - build/publish
 
 jobs:
   build:
@@ -47,10 +43,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment:
-      # TODO: update this to 'pypi' after testing publishing flow
-      name: testpypi
-      # TODO: update this to https://pypi.org/p/sgid-client after testing publishing flow
-      url: https://test.pypi.org/legacy/
+      name: pypi
+      url: https://pypi.org/p/sgid-client
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
@@ -59,9 +53,5 @@ jobs:
         with:
           name: dist-${{ github.sha }}
           path: dist/
-      # TODO: change this to "Publish package distributions to PyPI"
-      - name: Publish package distributions to TestPyPI
+      - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        # TODO: remove this after testing publishing flow
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [created]
+  # TODO: remove this
+  push:
+    branches:
+      - build/publish
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+        poetry-version: ['1.4.2']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up Poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: ${{ matrix.poetry-version }}
+      - name: Install dependencies
+        run: poetry install
+      - name: Build package distributions
+        run: poetry build
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        env:
+          # TODO: update this to 'pypi' after testing publishing flow
+          name: testpypi
+          # TODO: update this to https://pypi.org/p/sgid-client after testing publishing flow
+          url: https://test.pypi.org/legacy/
+        permissions:
+          id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+        # TODO: remove this after testing publishing flow
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upload package distribution artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: dist-${{ env.GITHUB_SHA }}
+          name: dist-${{ github.sha }}
           path: dist/
 
   publish:
@@ -57,7 +57,7 @@ jobs:
       - name: Download built package distributions
         uses: actions/download-artifact@v3
         with:
-          name: dist-${{ env.GITHUB_SHA }}
+          name: dist-${{ github.sha }}
           path: dist/
       # TODO: change this to "Publish package distributions to PyPI"
       - name: Publish package distributions to TestPyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,8 @@ on:
       - build/publish
 
 jobs:
-  publish:
-    name: Publish to PyPI
+  test-build:
+    name: Run tests and build package distribution
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,17 +29,38 @@ jobs:
           poetry-version: ${{ matrix.poetry-version }}
       - name: Install dependencies
         run: poetry install
+      - name: Run tests
+        run: poetry run pytest
       - name: Build package distributions
         run: poetry build
+        # Best practice to separate build and publish jobs,
+        # so any malicious scripts injected into build environment
+        # cannot elevate permissions
+      - name: Upload package distribution artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist-${{ env.GITHUB_SHA }}
+          path: dist/
+
+  publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      # TODO: update this to 'pypi' after testing publishing flow
+      name: testpypi
+      # TODO: update this to https://pypi.org/p/sgid-client after testing publishing flow
+      url: https://test.pypi.org/legacy/
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - name: Download built package distributions
+        uses: actions/download-artifact@v3
+        with:
+          name: dist-${{ env.GITHUB_SHA }}
+          path: dist/
+      # TODO: change this to "Publish package distributions to PyPI"
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        env:
-          # TODO: update this to 'pypi' after testing publishing flow
-          name: testpypi
-          # TODO: update this to https://pypi.org/p/sgid-client after testing publishing flow
-          url: https://test.pypi.org/legacy/
-        permissions:
-          id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
         # TODO: remove this after testing publishing flow
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
       - build/publish
 
 jobs:
-  test-build:
+  build:
     name: Run tests and build package distribution
     runs-on: ubuntu-latest
     strategy:
@@ -44,6 +44,7 @@ jobs:
 
   publish:
     name: Upload release to PyPI
+    needs: build
     runs-on: ubuntu-latest
     environment:
       # TODO: update this to 'pypi' after testing publishing flow


### PR DESCRIPTION
Adds an automated publishing pipeline on creation of releases.

## Rationale for deviating from NodeJS SDK release pipeline
The NodeJS SDK release pipeline requires allowing a single developer to independently publish releases without approval. The [release process](https://www.notion.so/opengov/Release-Guide-aa02a75ce1354e3b94e80f6181a02d70?pvs=4#522788c41b604ba49ff69de2f148615e) for this SDK is designed to require approval before releases are published.

## How this pipeline was tested
In 5aab97ae262d152f0d8c81f944a483a6d3005805, I replaced the references to the actual PyPI repository with TestPyPI. It successfully uploaded the package here: https://test.pypi.org/project/sgid-client/

The one issue with the [action](https://github.com/opengovsg/sgid-client-python/actions/runs/5009686102/jobs/8978874257) was that the artifact name was simply `dist-` rather than `dist-<insert commit hash>`. I fixed this in 6c339ddb64f4ca3e1c19c38335fca45e0fe47bfe (see [relevant action](https://github.com/opengovsg/sgid-client-python/actions/runs/5009744843/jobs/8978983976)), although the [publishing](https://github.com/opengovsg/sgid-client-python/actions/runs/5009744843/jobs/8978990565) subsequently failed because the same files had already been uploaded to TestPyPI.

## Next steps
Once all current PRs are approved, we should:
- [x] Create a shared sgID account on PyPI
- [ ] Add this repo as a trusted publisher following [these instructions](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
- [ ] Follow the instructions in the [release guide](https://www.notion.so/opengov/Release-Guide-aa02a75ce1354e3b94e80f6181a02d70?pvs=4#522788c41b604ba49ff69de2f148615e) to publish the prerelease, EXCEPT manually change the version in `pyproject.toml` to `0.1.0a0` so we can test before publishing `0.1.0`.
- [ ] In the Flask demo app, install the package from the prerelease version in PyPI and check that it works.
- [ ] Repeat steps 3 and 4 using the version `0.1.0`.