### PR TITLE
feat: used NamedTuple instead of TypedDict

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ generate_pkce_pair(length=43)
 
 - Args:
   - `length` (`int`, optional): The length of the code verifier. Defaults to 43.
-- Returns: `dict`
+- Returns: `NamedTuple`
   - `code_verifier`: `str` Randomly generated string
   - `code_challenge`: `str` S256 hash of code verifier
 
@@ -78,7 +78,7 @@ authorization_url(
   - `nonce` (`str | None`, optional): Unique nonce for this request. If this param is
     not provided, a nonce is generated and returned. To prevent this behaviour,
     specify None for this param. Defaults to `secrets.token_urlsafe(32)`.
-- Returns: `dict`
+- Returns: `NamedTuple`
   - `url`: `str` Generated authorization url.
   - `nonce`: `str | None` Provided nonce, randomly generated nonce, or `None` (based on nonce input).
     Should be stored in the user's session so it can be retrieved later for use in `callback`.
@@ -110,7 +110,7 @@ callback(
     Specify None if no nonce was passed to `authorization_url`. Defaults to None.
   - `redirect_uri` (`str | None`, optional): The redirect URI used in the authorization
     request. If not specified, defaults to the one passed to the SgidClient constructor.
-- Returns: `dict`
+- Returns: `NamedTuple`
   - `sub`: `str` Represents a unique identifer for the end-user.
   - `access_token`: `str` Access token used to request user info.
 
@@ -133,7 +133,7 @@ userinfo(sub: str, access_token: str)
 - Args:
   - `sub` (`str`): The sub returned from the callback function
   - `access_token` (`str`): The access token returned from the callback function
-- Returns: `dict`
+- Returns: `NamedTuple`
   - `sub`: `str` Represents a unique identifer for the end-user.
   - `data`: `dict` A dictionary containing end-user info where the keys are the scopes requested in `authorization_url`.
 

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -48,15 +48,15 @@ def get_auth_url():
     # so after they log in, we can display it together with the
     # other user info.
     code_verifier, code_challenge = generate_pkce_pair()
-    auth_url_and_nonce = sgid_client.authorization_url(
+    url, nonce = sgid_client.authorization_url(
         state=state, code_challenge=code_challenge
     )
     session_data[session_id] = {
         "state": state,
-        "nonce": auth_url_and_nonce.nonce,
+        "nonce": nonce,
         "code_verifier": code_verifier,
     }
-    res = make_response({"url": auth_url_and_nonce.url})
+    res = make_response({"url": url})
     res.set_cookie(SESSION_COOKIE_NAME, session_id, httponly=True)
     return res
 

--- a/examples/flask/poetry.lock
+++ b/examples/flask/poetry.lock
@@ -540,7 +540,7 @@ requests = "^2.30.0"
 type = "git"
 url = "https://github.com/opengovsg/sgid-client-python.git"
 reference = "feat/init-build"
-resolved_reference = "157295909be744f20eacc92c6f5500739d9280f2"
+resolved_reference = "1ff8f67064b892264c705e9fe3e22dd3075f1706"
 
 [[package]]
 name = "six"

--- a/sgid_client/IdTokenVerifier.py
+++ b/sgid_client/IdTokenVerifier.py
@@ -12,7 +12,7 @@ class IdTokenVerifier:
         res = requests.get(self.jwks_uri)
         if res.status_code != 200:
             error_message = get_network_error_message(
-                message=Errors["JWKS_ENDPOINT_FAILED"],
+                message=Errors.JWKS_ENDPOINT_FAILED,
                 status=res.status_code,
                 body=res.text,
             )
@@ -30,4 +30,4 @@ class IdTokenVerifier:
             try:
                 jwt_lib.JWT(key=self.jwks_cache, jwt=jwt)
             except:
-                raise Exception(Errors["ID_TOKEN_SIGNATURE_INVALID"])
+                raise Exception(Errors.ID_TOKEN_SIGNATURE_INVALID)

--- a/sgid_client/decrypt_data.py
+++ b/sgid_client/decrypt_data.py
@@ -7,14 +7,14 @@ def decrypt_data(encrypted_key: str, encrypted_data: dict, private_key: str):
         # Load private_key
         private_key_jwk = jwk.JWK.from_pem(private_key.encode("ascii"))
     except Exception as exc:
-        raise Exception(Errors["PRIVATE_KEY_IMPORT"]) from exc
+        raise Exception(Errors.PRIVATE_KEY_IMPORT) from exc
 
     try:
         jwe_key = jwe.JWE()
         # Decrypt encrypted_key to get block_key
         jwe_key.deserialize(encrypted_key, key=private_key_jwk)
     except Exception as exc:
-        raise Exception(Errors["USERINFO_BLOCK_KEY_DECRYPT_FAILED"]) from exc
+        raise Exception(Errors.USERINFO_BLOCK_KEY_DECRYPT_FAILED) from exc
 
     block_key_json = jwe_key.payload
     try:
@@ -30,6 +30,6 @@ def decrypt_data(encrypted_key: str, encrypted_data: dict, private_key: str):
             jwe_data.deserialize(encrypted_data[field], key=block_key)
             data_dict[field] = jwe_data.payload.decode("ascii")
     except Exception as exc:
-        raise Exception(Errors["USERINFO_DATA_DECRYPT_FAILED"]) from exc
+        raise Exception(Errors.USERINFO_DATA_DECRYPT_FAILED) from exc
 
     return data_dict

--- a/sgid_client/error.py
+++ b/sgid_client/error.py
@@ -1,10 +1,10 @@
-from typing import TypedDict
+from typing import NamedTuple
 from datetime import datetime
 
 from requests import Response
 
 
-class SgidClientError(TypedDict):
+class SgidClientError(NamedTuple):
     MISSING_REDIRECT_URI: str
     TOKEN_ENDPOINT_FAILED: str
     ID_TOKEN_MALFORMED: str
@@ -30,31 +30,31 @@ class SgidClientError(TypedDict):
     PKCE_PAIR_LENGTH_ERROR: str
 
 
-Errors: SgidClientError = {
-    "MISSING_REDIRECT_URI": "No redirect URI registered with this client. You must either specify a valid redirect URI in the SgidClient constructor, or pass it to the authorization_url and callback functions.",
-    "TOKEN_ENDPOINT_FAILED": "sgID responded with an error at the token endpoint",
-    "ID_TOKEN_MALFORMED": "sgID server returned a malformed ID token which did not contain the expected components (header, payload, signature)",
-    "ID_TOKEN_HEADER_PAYLOAD_MALFORMED": "ID token header or payload was malformed",
-    "ID_TOKEN_WRONG_SIGNING_ALG": "Unexpected signing algorithm used for ID token",
-    "ID_TOKEN_MISSING_KEYS": "ID token payload did not contain the required keys",
-    "ID_TOKEN_ISS_MISMATCH": "ID token 'iss' did not match expected value",
-    "ID_TOKEN_IAT_INVALID": "ID token 'iat' is invalid",
-    "ID_TOKEN_EXP_INVALID": "ID token 'exp' is invalid",
-    "ID_TOKEN_EXPIRED": "ID token is expired",
-    "ID_TOKEN_AUD_MISMATCH": "ID token 'aud' did not match client ID",
-    "ID_TOKEN_NONCE_MISMATCH": "ID token 'nonce' did not match the nonce passed to the callback function",
-    "ID_TOKEN_SUB_INVALID": "ID token 'sub' is invalid",
-    "ID_TOKEN_SIGNATURE_INVALID": "ID token signature is invalid",
-    "ACCESS_TOKEN_INVALID": "sgID token endpoint did not return a valid access token. Expected a non-empty string.",
-    "USERINFO_ENDPOINT_FAILED": "sgID responded with an error at the userinfo endpoint",
-    "JWKS_ENDPOINT_FAILED": "sgID responded with an error at the jwks endpoint",
-    "USERINFO_SUB_MISMATCH": "Sub returned by sgID did not match the sub passed to the userinfo method. Check that you passed the correct sub to the userinfo method.",
-    "PRIVATE_KEY_IMPORT": "Failed to import private key. Check that privateKey is a valid PKCS1 or PKCS8 key.",
-    "USERINFO_BLOCK_KEY_DECRYPT_FAILED": "Decryption of block key failed. Check that you passed the correct private key to the SgidClient constructor.",
-    "USERINFO_DATA_DECRYPT_FAILED": "Decryption of data failed. Check that you passed the correct private key to the SgidClient constructor.",
-    "CODE_VERIFIER_LENGTH_ERROR": "Code verifier should have a minimum length of 43 and a maximum length of 128",
-    "PKCE_PAIR_LENGTH_ERROR": "generate_pkce_pair should receive a minimum length of 43 and a maximum length of 128",
-}
+Errors = SgidClientError(
+    MISSING_REDIRECT_URI="No redirect URI registered with this client. You must either specify a valid redirect URI in the SgidClient constructor, or pass it to the authorization_url and callback functions.",
+    TOKEN_ENDPOINT_FAILED="sgID responded with an error at the token endpoint",
+    ID_TOKEN_MALFORMED="sgID server returned a malformed ID token which did not contain the expected components (header, payload, signature)",
+    ID_TOKEN_HEADER_PAYLOAD_MALFORMED="ID token header or payload was malformed",
+    ID_TOKEN_WRONG_SIGNING_ALG="Unexpected signing algorithm used for ID token",
+    ID_TOKEN_MISSING_KEYS="ID token payload did not contain the required keys",
+    ID_TOKEN_ISS_MISMATCH="ID token 'iss' did not match expected value",
+    ID_TOKEN_IAT_INVALID="ID token 'iat' is invalid",
+    ID_TOKEN_EXP_INVALID="ID token 'exp' is invalid",
+    ID_TOKEN_EXPIRED="ID token is expired",
+    ID_TOKEN_AUD_MISMATCH="ID token 'aud' did not match client ID",
+    ID_TOKEN_NONCE_MISMATCH="ID token 'nonce' did not match the nonce passed to the callback function",
+    ID_TOKEN_SUB_INVALID="ID token 'sub' is invalid",
+    ID_TOKEN_SIGNATURE_INVALID="ID token signature is invalid",
+    ACCESS_TOKEN_INVALID="sgID token endpoint did not return a valid access token. Expected a non-empty string.",
+    USERINFO_ENDPOINT_FAILED="sgID responded with an error at the userinfo endpoint",
+    JWKS_ENDPOINT_FAILED="sgID responded with an error at the jwks endpoint",
+    USERINFO_SUB_MISMATCH="Sub returned by sgID did not match the sub passed to the userinfo method. Check that you passed the correct sub to the userinfo method.",
+    PRIVATE_KEY_IMPORT="Failed to import private key. Check that privateKey is a valid PKCS1 or PKCS8 key.",
+    USERINFO_BLOCK_KEY_DECRYPT_FAILED="Decryption of block key failed. Check that you passed the correct private key to the SgidClient constructor.",
+    USERINFO_DATA_DECRYPT_FAILED="Decryption of data failed. Check that you passed the correct private key to the SgidClient constructor.",
+    CODE_VERIFIER_LENGTH_ERROR="Code verifier should have a minimum length of 43 and a maximum length of 128",
+    PKCE_PAIR_LENGTH_ERROR="generate_pkce_pair should receive a minimum length of 43 and a maximum length of 128",
+)
 
 
 def get_network_error_message(message: str, status: int, body: str) -> str:

--- a/sgid_client/generators.py
+++ b/sgid_client/generators.py
@@ -1,11 +1,11 @@
-from typing import TypedDict
+from typing import NamedTuple
 from .error import Errors
 import secrets
 from base64 import urlsafe_b64encode
 import hashlib
 
 
-class GeneratePkcePairReturn(TypedDict):
+class GeneratePkcePairReturn(NamedTuple):
     code_verifier: str
     code_challenge: str
 
@@ -24,7 +24,7 @@ def generate_code_verifier(length=43) -> str:
         str: The generated code verifier.
     """
     if length < 43 or length > 128:
-        raise Exception(Errors["CODE_VERIFIER_LENGTH_ERROR"])
+        raise Exception(Errors.CODE_VERIFIER_LENGTH_ERROR)
     bytes = secrets.token_bytes(96)
     encoded = urlsafe_b64encode(bytes)
     return encoded.decode("ascii")[:length]
@@ -61,7 +61,7 @@ def generate_pkce_pair(length=43) -> GeneratePkcePairReturn:
         GeneratePkcePairReturn: Code challenge and code verifier.
     """
     if length < 43 or length > 128:
-        raise Exception(Errors["PKCE_PAIR_LENGTH_ERROR"])
+        raise Exception(Errors.PKCE_PAIR_LENGTH_ERROR)
     verifier = generate_code_verifier(length)
     challenge = generate_code_challenge(verifier)
-    return {"code_verifier": verifier, "code_challenge": challenge}
+    return GeneratePkcePairReturn(code_verifier=verifier, code_challenge=challenge)

--- a/sgid_client/util.py
+++ b/sgid_client/util.py
@@ -19,4 +19,4 @@ def convert_to_pkcs8(private_key: str) -> str:
         imported = RSA.import_key(extern_key=private_key)
         return imported.export_key(pkcs=8).decode("ascii")
     except Exception as exc:
-        raise Exception(Errors["PRIVATE_KEY_IMPORT"]) from exc
+        raise Exception(Errors.PRIVATE_KEY_IMPORT) from exc

--- a/sgid_client/validation.py
+++ b/sgid_client/validation.py
@@ -12,7 +12,7 @@ from .error import (
 
 def validate_access_token(access_token: str):
     if type(access_token) is not str or access_token == "":
-        raise Exception(Errors["ACCESS_TOKEN_INVALID"])
+        raise Exception(Errors.ACCESS_TOKEN_INVALID)
 
 
 def validate_id_token(
@@ -24,14 +24,14 @@ def validate_id_token(
 ) -> str:
     id_token_components = id_token.split(".")
     if len(id_token_components) != 3:
-        raise Exception(Errors["ID_TOKEN_MALFORMED"])
+        raise Exception(Errors.ID_TOKEN_MALFORMED)
     try:
         # Avoid padding errors by appending the max possible padding.
         # b64decode will ignore any extra padding.
         header = json.loads(unquote(b64decode(id_token_components[0] + "==")))
         payload = json.loads(unquote(b64decode(id_token_components[1] + "==")))
     except:
-        raise Exception(Errors["ID_TOKEN_HEADER_PAYLOAD_MALFORMED"])
+        raise Exception(Errors.ID_TOKEN_HEADER_PAYLOAD_MALFORMED)
     validate_id_token_header(id_token_header=header)
     validate_id_token_payload(
         id_token_payload=payload, issuer=issuer, client_id=client_id, nonce=nonce
@@ -45,7 +45,7 @@ def validate_id_token_header(id_token_header: dict) -> None:
     if received_alg != "RS256":
         raise Exception(
             get_expected_vs_received_error_message(
-                message=Errors["ID_TOKEN_WRONG_SIGNING_ALG"],
+                message=Errors.ID_TOKEN_WRONG_SIGNING_ALG,
                 expected="RS256",
                 received=received_alg,
             )
@@ -67,7 +67,7 @@ def validate_id_token_payload(
     if len(present_keys) != len(required_keys):
         raise Exception(
             get_expected_vs_received_error_message(
-                message=Errors["ID_TOKEN_MISSING_KEYS"],
+                message=Errors.ID_TOKEN_MISSING_KEYS,
                 expected=",".join(required_keys),
                 received=",".join(present_keys),
             )
@@ -76,7 +76,7 @@ def validate_id_token_payload(
     if id_token_payload["iss"] != issuer:
         raise Exception(
             get_expected_vs_received_error_message(
-                message=Errors["ID_TOKEN_ISS_MISMATCH"],
+                message=Errors.ID_TOKEN_ISS_MISMATCH,
                 expected=issuer,
                 received=id_token_payload["iss"],
             )
@@ -85,7 +85,7 @@ def validate_id_token_payload(
     if type(id_token_payload["iat"]) is not int:
         raise Exception(
             get_expected_vs_received_error_message(
-                message=Errors["ID_TOKEN_IAT_INVALID"],
+                message=Errors.ID_TOKEN_IAT_INVALID,
                 expected="a valid number",
                 received=id_token_payload["iat"],
             )
@@ -94,7 +94,7 @@ def validate_id_token_payload(
     if type(id_token_payload["exp"]) is not int:
         raise Exception(
             get_expected_vs_received_error_message(
-                message=Errors["ID_TOKEN_EXP_INVALID"],
+                message=Errors.ID_TOKEN_EXP_INVALID,
                 expected="a valid number",
                 received=id_token_payload["exp"],
             )
@@ -104,14 +104,14 @@ def validate_id_token_payload(
     if id_token_payload["exp"] < curr_time.timestamp():
         raise Exception(
             get_expiry_error_message(
-                message=Errors["ID_TOKEN_EXPIRED"], expired_at=id_token_payload["exp"]
+                message=Errors.ID_TOKEN_EXPIRED, expired_at=id_token_payload["exp"]
             )
         )
 
     if id_token_payload["aud"] != client_id:
         raise Exception(
             get_expected_vs_received_error_message(
-                message=Errors["ID_TOKEN_AUD_MISMATCH"],
+                message=Errors.ID_TOKEN_AUD_MISMATCH,
                 expected=client_id,
                 received=id_token_payload["aud"],
             )
@@ -121,7 +121,7 @@ def validate_id_token_payload(
     if nonce is not None and nonce_received != nonce:
         raise Exception(
             get_expected_vs_received_error_message(
-                message=Errors["ID_TOKEN_NONCE_MISMATCH"],
+                message=Errors.ID_TOKEN_NONCE_MISMATCH,
                 expected=nonce,
                 received=nonce_received,
             )
@@ -130,7 +130,7 @@ def validate_id_token_payload(
     if type(id_token_payload["sub"]) is not str or id_token_payload["sub"] == "":
         raise Exception(
             get_expected_vs_received_error_message(
-                message=Errors["ID_TOKEN_SUB_INVALID"],
+                message=Errors.ID_TOKEN_SUB_INVALID,
                 expected="a non-empty string",
                 received=id_token_payload["sub"],
             )

--- a/tests/SgidClient_authorization_url_test.py
+++ b/tests/SgidClient_authorization_url_test.py
@@ -18,25 +18,25 @@ class TestAuthorizationUrl:
         mock_code_challenge = "mockCodeChallenge"
 
         # Act
-        url_and_nonce = client.authorization_url(
+        url, nonce = client.authorization_url(
             state=mock_state, code_challenge=mock_code_challenge
         )
-        url = urlparse(url_and_nonce["url"])
-        query = parse_qs(url.query)
+        parsed_url = urlparse(url)
+        query = parse_qs(parsed_url.query)
 
         # Assert
         assert (
-            f"{url.scheme}://{url.hostname}{url.path}"
-            == MOCK_CONSTANTS["server"]["auth_endpoint"]
+            f"{parsed_url.scheme}://{parsed_url.hostname}{parsed_url.path}"
+            == MOCK_CONSTANTS.server["auth_endpoint"]
         )
         # No repeated values
         for val in query.values():
             assert len(val) == 1
-        assert query["client_id"][0] == MOCK_CONSTANTS["client"]["client_id"]
+        assert query["client_id"][0] == MOCK_CONSTANTS.client["client_id"]
         assert query["scope"][0] == DEFAULT_SCOPE
         assert query["response_type"][0] == DEFAULT_RESPONSE_TYPE
-        assert query["redirect_uri"][0] == MOCK_CONSTANTS["client"]["redirect_uri"]
-        assert query["nonce"][0] == url_and_nonce["nonce"]
+        assert query["redirect_uri"][0] == MOCK_CONSTANTS.client["redirect_uri"]
+        assert query["nonce"][0] == nonce
         assert query["state"][0] == mock_state
         assert query["code_challenge"][0] == mock_code_challenge
         assert query["code_challenge_method"][0] == DEFAULT_SGID_CODE_CHALLENGE_METHOD
@@ -51,25 +51,25 @@ class TestAuthorizationUrl:
         mock_scope = "mockScope"
 
         # Act
-        url_and_nonce = client.authorization_url(
+        url, nonce = client.authorization_url(
             state=mock_state, code_challenge=mock_code_challenge, scope=mock_scope
         )
-        url = urlparse(url_and_nonce["url"])
-        query = parse_qs(url.query)
+        parsed_url = urlparse(url)
+        query = parse_qs(parsed_url.query)
 
         # Assert
         assert (
-            f"{url.scheme}://{url.hostname}{url.path}"
-            == MOCK_CONSTANTS["server"]["auth_endpoint"]
+            f"{parsed_url.scheme}://{parsed_url.hostname}{parsed_url.path}"
+            == MOCK_CONSTANTS.server["auth_endpoint"]
         )
         # No repeated values
         for val in query.values():
             assert len(val) == 1
-        assert query["client_id"][0] == MOCK_CONSTANTS["client"]["client_id"]
+        assert query["client_id"][0] == MOCK_CONSTANTS.client["client_id"]
         assert query["scope"][0] == mock_scope
         assert query["response_type"][0] == DEFAULT_RESPONSE_TYPE
-        assert query["redirect_uri"][0] == MOCK_CONSTANTS["client"]["redirect_uri"]
-        assert query["nonce"][0] == url_and_nonce["nonce"]
+        assert query["redirect_uri"][0] == MOCK_CONSTANTS.client["redirect_uri"]
+        assert query["nonce"][0] == nonce
         assert query["state"][0] == mock_state
         assert query["code_challenge"][0] == mock_code_challenge
         assert query["code_challenge_method"][0] == DEFAULT_SGID_CODE_CHALLENGE_METHOD
@@ -84,25 +84,25 @@ class TestAuthorizationUrl:
         mock_scope = ["scope1", "scope2", "scope3"]
 
         # Act
-        url_and_nonce = client.authorization_url(
+        url, nonce = client.authorization_url(
             state=mock_state, code_challenge=mock_code_challenge, scope=mock_scope
         )
-        url = urlparse(url_and_nonce["url"])
-        query = parse_qs(url.query)
+        parsed_url = urlparse(url)
+        query = parse_qs(parsed_url.query)
 
         # Assert
         assert (
-            f"{url.scheme}://{url.hostname}{url.path}"
-            == MOCK_CONSTANTS["server"]["auth_endpoint"]
+            f"{parsed_url.scheme}://{parsed_url.hostname}{parsed_url.path}"
+            == MOCK_CONSTANTS.server["auth_endpoint"]
         )
         # No repeated values
         for val in query.values():
             assert len(val) == 1
-        assert query["client_id"][0] == MOCK_CONSTANTS["client"]["client_id"]
+        assert query["client_id"][0] == MOCK_CONSTANTS.client["client_id"]
         assert query["scope"][0] == " ".join(mock_scope)
         assert query["response_type"][0] == DEFAULT_RESPONSE_TYPE
-        assert query["redirect_uri"][0] == MOCK_CONSTANTS["client"]["redirect_uri"]
-        assert query["nonce"][0] == url_and_nonce["nonce"]
+        assert query["redirect_uri"][0] == MOCK_CONSTANTS.client["redirect_uri"]
+        assert query["nonce"][0] == nonce
         assert query["state"][0] == mock_state
         assert query["code_challenge"][0] == mock_code_challenge
         assert query["code_challenge_method"][0] == DEFAULT_SGID_CODE_CHALLENGE_METHOD
@@ -117,26 +117,26 @@ class TestAuthorizationUrl:
         mock_nonce = "mockNonce"
 
         # Act
-        url_and_nonce = client.authorization_url(
+        url, nonce = client.authorization_url(
             state=mock_state, code_challenge=mock_code_challenge, nonce=mock_nonce
         )
-        url = urlparse(url_and_nonce["url"])
-        query = parse_qs(url.query)
+        parsed_url = urlparse(url)
+        query = parse_qs(parsed_url.query)
 
         # Assert
         assert (
-            f"{url.scheme}://{url.hostname}{url.path}"
-            == MOCK_CONSTANTS["server"]["auth_endpoint"]
+            f"{parsed_url.scheme}://{parsed_url.hostname}{parsed_url.path}"
+            == MOCK_CONSTANTS.server["auth_endpoint"]
         )
         # No repeated values
         for val in query.values():
             assert len(val) == 1
-        assert query["client_id"][0] == MOCK_CONSTANTS["client"]["client_id"]
+        assert query["client_id"][0] == MOCK_CONSTANTS.client["client_id"]
         assert query["scope"][0] == DEFAULT_SCOPE
         assert query["response_type"][0] == DEFAULT_RESPONSE_TYPE
-        assert query["redirect_uri"][0] == MOCK_CONSTANTS["client"]["redirect_uri"]
-        assert query["nonce"][0] == url_and_nonce["nonce"]
-        assert url_and_nonce["nonce"] == mock_nonce
+        assert query["redirect_uri"][0] == MOCK_CONSTANTS.client["redirect_uri"]
+        assert query["nonce"][0] == nonce
+        assert nonce == mock_nonce
         assert query["state"][0] == mock_state
         assert query["code_challenge"][0] == mock_code_challenge
         assert query["code_challenge_method"][0] == DEFAULT_SGID_CODE_CHALLENGE_METHOD
@@ -150,25 +150,25 @@ class TestAuthorizationUrl:
         mock_code_challenge = "mockCodeChallenge"
 
         # Act
-        url_and_nonce = client.authorization_url(
+        url, nonce = client.authorization_url(
             state=mock_state, code_challenge=mock_code_challenge, nonce=None
         )
-        url = urlparse(url_and_nonce["url"])
-        query = parse_qs(url.query)
+        parsed_url = urlparse(url)
+        query = parse_qs(parsed_url.query)
 
         # Assert
         assert (
-            f"{url.scheme}://{url.hostname}{url.path}"
-            == MOCK_CONSTANTS["server"]["auth_endpoint"]
+            f"{parsed_url.scheme}://{parsed_url.hostname}{parsed_url.path}"
+            == MOCK_CONSTANTS.server["auth_endpoint"]
         )
         # No repeated values
         for val in query.values():
             assert len(val) == 1
-        assert query["client_id"][0] == MOCK_CONSTANTS["client"]["client_id"]
+        assert query["client_id"][0] == MOCK_CONSTANTS.client["client_id"]
         assert query["scope"][0] == DEFAULT_SCOPE
         assert query["response_type"][0] == DEFAULT_RESPONSE_TYPE
-        assert query["redirect_uri"][0] == MOCK_CONSTANTS["client"]["redirect_uri"]
-        assert url_and_nonce["nonce"] is None
+        assert query["redirect_uri"][0] == MOCK_CONSTANTS.client["redirect_uri"]
+        assert nonce is None
         assert query["state"][0] == mock_state
         assert query["code_challenge"][0] == mock_code_challenge
         assert query["code_challenge_method"][0] == DEFAULT_SGID_CODE_CHALLENGE_METHOD
@@ -183,27 +183,27 @@ class TestAuthorizationUrl:
         mock_redirect_uri = "mockRedirectUri"
 
         # Act
-        url_and_nonce = client.authorization_url(
+        url, nonce = client.authorization_url(
             state=mock_state,
             code_challenge=mock_code_challenge,
             redirect_uri=mock_redirect_uri,
         )
-        url = urlparse(url_and_nonce["url"])
-        query = parse_qs(url.query)
+        parsed_url = urlparse(url)
+        query = parse_qs(parsed_url.query)
 
         # Assert
         assert (
-            f"{url.scheme}://{url.hostname}{url.path}"
-            == MOCK_CONSTANTS["server"]["auth_endpoint"]
+            f"{parsed_url.scheme}://{parsed_url.hostname}{parsed_url.path}"
+            == MOCK_CONSTANTS.server["auth_endpoint"]
         )
         # No repeated values
         for val in query.values():
             assert len(val) == 1
-        assert query["client_id"][0] == MOCK_CONSTANTS["client"]["client_id"]
+        assert query["client_id"][0] == MOCK_CONSTANTS.client["client_id"]
         assert query["scope"][0] == DEFAULT_SCOPE
         assert query["response_type"][0] == DEFAULT_RESPONSE_TYPE
         assert query["redirect_uri"][0] == mock_redirect_uri
-        assert query["nonce"][0] == url_and_nonce["nonce"]
+        assert query["nonce"][0] == nonce
         assert query["state"][0] == mock_state
         assert query["code_challenge"][0] == mock_code_challenge
         assert query["code_challenge_method"][0] == DEFAULT_SGID_CODE_CHALLENGE_METHOD

--- a/tests/SgidClient_callback_test.py
+++ b/tests/SgidClient_callback_test.py
@@ -20,25 +20,22 @@ class TestCallback:
         client = get_client()
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
         # Act
-        sub_and_access_token = client.callback(
-            code=MOCK_CONSTANTS["data"]["auth_code"],
-            code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+        sub, access_token = client.callback(
+            code=MOCK_CONSTANTS.data["auth_code"],
+            code_verifier=MOCK_CONSTANTS.data["code_verifier"],
         )
 
         # Assert
-        assert sub_and_access_token["sub"] == MOCK_CONSTANTS["data"]["sub"]
-        assert (
-            sub_and_access_token["access_token"]
-            == MOCK_CONSTANTS["data"]["access_token"]
-        )
+        assert sub == MOCK_CONSTANTS.data["sub"]
+        assert access_token == MOCK_CONSTANTS.data["access_token"]
 
     @responses.activate
     def test_success_with_nonce(self):
@@ -47,26 +44,23 @@ class TestCallback:
         nonce = "mockNonce"
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(nonce=nonce),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
         # Act
-        sub_and_access_token = client.callback(
-            code=MOCK_CONSTANTS["data"]["auth_code"],
-            code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+        sub, access_token = client.callback(
+            code=MOCK_CONSTANTS.data["auth_code"],
+            code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             nonce=nonce,
         )
 
         # Assert
-        assert sub_and_access_token["sub"] == MOCK_CONSTANTS["data"]["sub"]
-        assert (
-            sub_and_access_token["access_token"]
-            == MOCK_CONSTANTS["data"]["access_token"]
-        )
+        assert sub == MOCK_CONSTANTS.data["sub"]
+        assert access_token == MOCK_CONSTANTS.data["access_token"]
 
     @responses.activate
     def test_success_refetch_jwks(self):
@@ -75,41 +69,32 @@ class TestCallback:
         # First return a non-working public key from jwks, then a working one
         # SgidClient should refetch the public key when the non-working one fails
         responses.add(
-            get_jwks_response(json=MOCK_CONSTANTS["server"]["public_jwks_alternate"])
+            get_jwks_response(json=MOCK_CONSTANTS.server["public_jwks_alternate"])
         )
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
         # Act
-        sub_and_access_token = client.callback(
-            code=MOCK_CONSTANTS["data"]["auth_code"],
-            code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+        sub, access_token = client.callback(
+            code=MOCK_CONSTANTS.data["auth_code"],
+            code_verifier=MOCK_CONSTANTS.data["code_verifier"],
         )
 
         # Assert
         assert len(responses.calls) == 3  # 1 to token, 2 to jwks
-        assert (
-            responses.calls[0].request.url == MOCK_CONSTANTS["server"]["token_endpoint"]
-        )
+        assert responses.calls[0].request.url == MOCK_CONSTANTS.server["token_endpoint"]
         # call to get jwks for which signature validation fails
-        assert (
-            responses.calls[1].request.url == MOCK_CONSTANTS["server"]["jwks_endpoint"]
-        )
+        assert responses.calls[1].request.url == MOCK_CONSTANTS.server["jwks_endpoint"]
         # call to get updated jwks
-        assert (
-            responses.calls[2].request.url == MOCK_CONSTANTS["server"]["jwks_endpoint"]
-        )
-        assert sub_and_access_token["sub"] == MOCK_CONSTANTS["data"]["sub"]
-        assert (
-            sub_and_access_token["access_token"]
-            == MOCK_CONSTANTS["data"]["access_token"]
-        )
+        assert responses.calls[2].request.url == MOCK_CONSTANTS.server["jwks_endpoint"]
+        assert sub == MOCK_CONSTANTS.data["sub"]
+        assert access_token == MOCK_CONSTANTS.data["access_token"]
 
     @responses.activate
     def test_token_endpoint_failure(self):
@@ -118,7 +103,7 @@ class TestCallback:
         responses.add(get_jwks_response())
         response_json = {"message": "Your request is invalid"}
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json=response_json,
             status=400,
         )
@@ -128,9 +113,9 @@ class TestCallback:
             Exception,
             match=f"sgID responded with an error at the token endpoint\nResponse status: 400\nResponse body: {json.dumps(response_json)}",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -139,10 +124,10 @@ class TestCallback:
         client = get_client()
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": "abc.def",
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -153,9 +138,9 @@ class TestCallback:
                 "sgID server returned a malformed ID token which did not contain the expected components (header, payload, signature)"
             ),
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -164,10 +149,10 @@ class TestCallback:
         client = get_client()
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": f"abc.{make_base64url_json({'a': 1})}.ghi",
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -176,9 +161,9 @@ class TestCallback:
             Exception,
             match="ID token header or payload was malformed",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -187,10 +172,10 @@ class TestCallback:
         client = get_client()
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": f"{make_base64url_json({'a': 1})}.def.ghi",
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -199,9 +184,9 @@ class TestCallback:
             Exception,
             match="ID token header or payload was malformed",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -211,10 +196,10 @@ class TestCallback:
         invalid_alg = "HS256"
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": f"{make_base64url_json({'alg': invalid_alg})}.{make_base64url_json({'a': 1})}.ghi",
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -223,9 +208,9 @@ class TestCallback:
             Exception,
             match=f"Unexpected signing algorithm used for ID token. Expected RS256, received {invalid_alg}.",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -234,10 +219,10 @@ class TestCallback:
         client = get_client()
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(delete_keys=["iss", "sub", "aud", "exp"]),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -246,9 +231,9 @@ class TestCallback:
             Exception,
             match=f"ID token payload did not contain the required keys. Expected iss,sub,aud,exp,iat, received iat.",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -258,21 +243,21 @@ class TestCallback:
         responses.add(get_jwks_response())
         invalid_iss = "invalid"
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(iss=invalid_iss),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
         # Act + Assert
         with pytest.raises(
             Exception,
-            match=f"ID token 'iss' did not match expected value. Expected {MOCK_CONSTANTS['server']['hostname'] + '/v2'}, received {invalid_iss}",
+            match=f"ID token 'iss' did not match expected value. Expected {MOCK_CONSTANTS.server['hostname'] + '/v2'}, received {invalid_iss}",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -282,10 +267,10 @@ class TestCallback:
         responses.add(get_jwks_response())
         invalid_iat = "invalid"
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(iat=invalid_iat),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -294,9 +279,9 @@ class TestCallback:
             Exception,
             match=f"ID token 'iat' is invalid. Expected a valid number, received {invalid_iat}",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -306,10 +291,10 @@ class TestCallback:
         responses.add(get_jwks_response())
         invalid_exp = "invalid"
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(exp=invalid_exp),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -318,9 +303,9 @@ class TestCallback:
             Exception,
             match=f"ID token 'exp' is invalid. Expected a valid number, received {invalid_exp}",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -330,10 +315,10 @@ class TestCallback:
         responses.add(get_jwks_response())
         five_min_ago = math.floor(datetime.now().timestamp() - 300)
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(exp=five_min_ago),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -342,9 +327,9 @@ class TestCallback:
             Exception,
             match=f"ID token is expired. Current timestamp is \\d+/\\d+/\\d+, \\d+:\\d+:\\d+, expiry was at \\d+/\\d+/\\d+, \\d+:\\d+:\\d+",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -354,21 +339,21 @@ class TestCallback:
         responses.add(get_jwks_response())
         invalid_aud = "invalidAud"
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(aud=invalid_aud),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
         # Act + Assert
         with pytest.raises(
             Exception,
-            match=f"ID token 'aud' did not match client ID. Expected {MOCK_CONSTANTS['client']['client_id']}, received {invalid_aud}.",
+            match=f"ID token 'aud' did not match client ID. Expected {MOCK_CONSTANTS.client['client_id']}, received {invalid_aud}.",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -379,10 +364,10 @@ class TestCallback:
         nonce = "mockNonce"
         invalid_nonce = "invalidNonce"
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(nonce=nonce),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -391,9 +376,9 @@ class TestCallback:
             Exception,
             match=f"ID token 'nonce' did not match the nonce passed to the callback function. Expected {invalid_nonce}, received {nonce}.",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
                 nonce=invalid_nonce,
             )
 
@@ -404,10 +389,10 @@ class TestCallback:
         responses.add(get_jwks_response())
         invalid_sub = 123
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(sub=invalid_sub),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -416,9 +401,9 @@ class TestCallback:
             Exception,
             match=f"ID token 'sub' is invalid. Expected a non-empty string, received {invalid_sub}.",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -427,10 +412,10 @@ class TestCallback:
         client = get_client()
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(sub=""),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -439,9 +424,9 @@ class TestCallback:
             Exception,
             match=f"ID token 'sub' is invalid. Expected a non-empty string, received .",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -450,13 +435,13 @@ class TestCallback:
         client = get_client()
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 # Pass in client's private key, which doesn't match server's public key
                 "id_token": create_id_token(
-                    private_key=MOCK_CONSTANTS["client"]["private_key"]
+                    private_key=MOCK_CONSTANTS.client["private_key"]
                 ),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -465,9 +450,9 @@ class TestCallback:
             Exception,
             match=f"ID token signature is invalid",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -476,15 +461,15 @@ class TestCallback:
         client = get_client()
         response_json = {"message": "Your request is invalid"}
         responses.get(
-            url=MOCK_CONSTANTS["server"]["jwks_endpoint"],
+            url=MOCK_CONSTANTS.server["jwks_endpoint"],
             json=response_json,
             status=400,
         )
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 "id_token": create_id_token(),
-                "access_token": MOCK_CONSTANTS["data"]["access_token"],
+                "access_token": MOCK_CONSTANTS.data["access_token"],
             },
         )
 
@@ -493,9 +478,9 @@ class TestCallback:
             Exception,
             match=f"sgID responded with an error at the jwks endpoint\nResponse status: 400\nResponse body: {json.dumps(response_json)}",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -504,7 +489,7 @@ class TestCallback:
         client = get_client()
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 # Pass in client's private key, which doesn't match server's public key
                 "id_token": create_id_token(),
@@ -517,9 +502,9 @@ class TestCallback:
             Exception,
             match=f"sgID token endpoint did not return a valid access token. Expected a non-empty string.",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )
 
     @responses.activate
@@ -528,7 +513,7 @@ class TestCallback:
         client = get_client()
         responses.add(get_jwks_response())
         responses.post(
-            url=MOCK_CONSTANTS["server"]["token_endpoint"],
+            url=MOCK_CONSTANTS.server["token_endpoint"],
             json={
                 # Pass in client's private key, which doesn't match server's public key
                 "id_token": create_id_token(),
@@ -541,7 +526,7 @@ class TestCallback:
             Exception,
             match=f"sgID token endpoint did not return a valid access token. Expected a non-empty string.",
         ):
-            sub_and_access_token = client.callback(
-                code=MOCK_CONSTANTS["data"]["auth_code"],
-                code_verifier=MOCK_CONSTANTS["data"]["code_verifier"],
+            sub, access_token = client.callback(
+                code=MOCK_CONSTANTS.data["auth_code"],
+                code_verifier=MOCK_CONSTANTS.data["code_verifier"],
             )

--- a/tests/SgidClient_constructor_test.py
+++ b/tests/SgidClient_constructor_test.py
@@ -12,7 +12,7 @@ class TestConstructor:
 
     def test_pkcs1(self):
         # Borrow server's PKCS1 private key to test that it imports correctly
-        client = get_client(private_key=MOCK_CONSTANTS["server"]["private_key"])
+        client = get_client(private_key=MOCK_CONSTANTS.server["private_key"])
         assert type(client) is SgidClient
 
     def test_hostname_default(self):

--- a/tests/SgidClient_userinfo_test.py
+++ b/tests/SgidClient_userinfo_test.py
@@ -13,10 +13,10 @@ from tests.mocks.helpers import (
 class TestUserInfo:
     def userinfo_callback(self, request: Request):
         auth_header: str = request.headers.get("authorization")
-        if auth_header != f"Bearer {MOCK_CONSTANTS['data']['access_token']}":
+        if auth_header != f"Bearer {MOCK_CONSTANTS.data['access_token']}":
             return (401, {}, {})
         result = {
-            "sub": MOCK_CONSTANTS["data"]["sub"],
+            "sub": MOCK_CONSTANTS.data["sub"],
             "key": generate_encrypted_block_key(),
             "data": generate_user_info(),
         }
@@ -27,28 +27,28 @@ class TestUserInfo:
         # Arrange
         responses.add_callback(
             responses.GET,
-            MOCK_CONSTANTS["server"]["userinfo_endpoint"],
+            MOCK_CONSTANTS.server["userinfo_endpoint"],
             callback=self.userinfo_callback,
             content_type="application/json",
         )
         client = get_client()
 
         # Act
-        sub_and_data = client.userinfo(
-            sub=MOCK_CONSTANTS["data"]["sub"],
-            access_token=MOCK_CONSTANTS["data"]["access_token"],
+        sub, data = client.userinfo(
+            sub=MOCK_CONSTANTS.data["sub"],
+            access_token=MOCK_CONSTANTS.data["access_token"],
         )
 
         # Assert
-        assert sub_and_data["sub"] == MOCK_CONSTANTS["data"]["sub"]
-        assert sub_and_data["data"] == MOCK_CONSTANTS["data"]["userinfo"]
+        assert sub == MOCK_CONSTANTS.data["sub"]
+        assert data == MOCK_CONSTANTS.data["userinfo"]
 
     @responses.activate
     def test_userinfo_endpoint_failure_no_res_headers(self):
         # Arrange
         response_json = {"message": "Your request is invalid"}
         responses.get(
-            url=MOCK_CONSTANTS["server"]["userinfo_endpoint"],
+            url=MOCK_CONSTANTS.server["userinfo_endpoint"],
             json=response_json,
             status=400,
         )
@@ -59,9 +59,9 @@ class TestUserInfo:
             Exception,
             match=f"sgID responded with an error at the userinfo endpoint\nResponse status: 400\nResponse body: {json.dumps(response_json)}",
         ):
-            sub_and_data = client.userinfo(
-                sub=MOCK_CONSTANTS["data"]["sub"],
-                access_token=MOCK_CONSTANTS["data"]["access_token"],
+            sub, data = client.userinfo(
+                sub=MOCK_CONSTANTS.data["sub"],
+                access_token=MOCK_CONSTANTS.data["access_token"],
             )
 
     @responses.activate
@@ -70,7 +70,7 @@ class TestUserInfo:
         response_json = {"message": "Your request is invalid"}
         www_auth_message = "Your request failed"
         responses.get(
-            url=MOCK_CONSTANTS["server"]["userinfo_endpoint"],
+            url=MOCK_CONSTANTS.server["userinfo_endpoint"],
             json=response_json,
             headers={"www-authenticate": f"error={www_auth_message}"},
             status=400,
@@ -82,9 +82,9 @@ class TestUserInfo:
             Exception,
             match=f"sgID responded with an error at the userinfo endpoint\nResponse status: 400\nError message: {www_auth_message}",
         ):
-            sub_and_data = client.userinfo(
-                sub=MOCK_CONSTANTS["data"]["sub"],
-                access_token=MOCK_CONSTANTS["data"]["access_token"],
+            sub, data = client.userinfo(
+                sub=MOCK_CONSTANTS.data["sub"],
+                access_token=MOCK_CONSTANTS.data["access_token"],
             )
 
     @responses.activate
@@ -93,7 +93,7 @@ class TestUserInfo:
         response_json = {"message": "Your request is invalid"}
         www_auth_message = "Your request failed"
         responses.get(
-            url=MOCK_CONSTANTS["server"]["userinfo_endpoint"],
+            url=MOCK_CONSTANTS.server["userinfo_endpoint"],
             json=response_json,
             headers={"www-authenticate": www_auth_message},
             status=400,
@@ -105,9 +105,9 @@ class TestUserInfo:
             Exception,
             match=f"sgID responded with an error at the userinfo endpoint\nResponse status: 400\nError message: {www_auth_message}",
         ):
-            sub_and_data = client.userinfo(
-                sub=MOCK_CONSTANTS["data"]["sub"],
-                access_token=MOCK_CONSTANTS["data"]["access_token"],
+            sub, data = client.userinfo(
+                sub=MOCK_CONSTANTS.data["sub"],
+                access_token=MOCK_CONSTANTS.data["access_token"],
             )
 
     @responses.activate
@@ -115,7 +115,7 @@ class TestUserInfo:
         # Arrange
         responses.add_callback(
             responses.GET,
-            MOCK_CONSTANTS["server"]["userinfo_endpoint"],
+            MOCK_CONSTANTS.server["userinfo_endpoint"],
             callback=self.userinfo_callback,
             content_type="application/json",
         )
@@ -127,18 +127,18 @@ class TestUserInfo:
             Exception,
             match=f"Sub returned by sgID did not match the sub passed to the userinfo method. Check that you passed the correct sub to the userinfo method.",
         ):
-            sub_and_data = client.userinfo(
+            sub, data = client.userinfo(
                 sub=sub_passed_to_userinfo,
-                access_token=MOCK_CONSTANTS["data"]["access_token"],
+                access_token=MOCK_CONSTANTS.data["access_token"],
             )
 
     @responses.activate
     def test_userinfo_block_key_decrypt_error(self):
         # Arrange
         responses.get(
-            url=MOCK_CONSTANTS["server"]["userinfo_endpoint"],
+            url=MOCK_CONSTANTS.server["userinfo_endpoint"],
             json={
-                "sub": MOCK_CONSTANTS["data"]["sub"],
+                "sub": MOCK_CONSTANTS.data["sub"],
                 "key": "invalidKey",
                 "data": generate_user_info(),
             },
@@ -150,18 +150,18 @@ class TestUserInfo:
             Exception,
             match=f"Decryption of block key failed. Check that you passed the correct private key to the SgidClient constructor.",
         ):
-            sub_and_data = client.userinfo(
-                sub=MOCK_CONSTANTS["data"]["sub"],
-                access_token=MOCK_CONSTANTS["data"]["access_token"],
+            sub, data = client.userinfo(
+                sub=MOCK_CONSTANTS.data["sub"],
+                access_token=MOCK_CONSTANTS.data["access_token"],
             )
 
     @responses.activate
     def test_userinfo_data_decrypt_error(self):
         # Arrange
         responses.get(
-            url=MOCK_CONSTANTS["server"]["userinfo_endpoint"],
+            url=MOCK_CONSTANTS.server["userinfo_endpoint"],
             json={
-                "sub": MOCK_CONSTANTS["data"]["sub"],
+                "sub": MOCK_CONSTANTS.data["sub"],
                 "key": generate_encrypted_block_key(),
                 "data": {"abc": "def"},
             },
@@ -173,7 +173,7 @@ class TestUserInfo:
             Exception,
             match=f"Decryption of data failed. Check that you passed the correct private key to the SgidClient constructor.",
         ):
-            sub_and_data = client.userinfo(
-                sub=MOCK_CONSTANTS["data"]["sub"],
-                access_token=MOCK_CONSTANTS["data"]["access_token"],
+            sub, data = client.userinfo(
+                sub=MOCK_CONSTANTS.data["sub"],
+                access_token=MOCK_CONSTANTS.data["access_token"],
             )

--- a/tests/generators_test.py
+++ b/tests/generators_test.py
@@ -34,17 +34,17 @@ class TestGenerateCodeVerifier:
 
 class TestGenerateCodeChallenge:
     def test_hash_correctness(self):
-        challenge = generate_code_challenge(MOCK_CONSTANTS["data"]["code_verifier"])
+        challenge = generate_code_challenge(MOCK_CONSTANTS.data["code_verifier"])
 
         assert re.fullmatch(verifier_challenge_pattern, challenge) is not None
-        assert challenge == MOCK_CONSTANTS["data"]["code_challenge"]
+        assert challenge == MOCK_CONSTANTS.data["code_challenge"]
 
     def test_determinism(self):
-        challenge_1 = generate_code_challenge(MOCK_CONSTANTS["data"]["code_verifier"])
-        challenge_2 = generate_code_challenge(MOCK_CONSTANTS["data"]["code_verifier"])
+        challenge_1 = generate_code_challenge(MOCK_CONSTANTS.data["code_verifier"])
+        challenge_2 = generate_code_challenge(MOCK_CONSTANTS.data["code_verifier"])
 
-        assert challenge_1 == MOCK_CONSTANTS["data"]["code_challenge"]
-        assert challenge_2 == MOCK_CONSTANTS["data"]["code_challenge"]
+        assert challenge_1 == MOCK_CONSTANTS.data["code_challenge"]
+        assert challenge_2 == MOCK_CONSTANTS.data["code_challenge"]
 
 
 class TestGeneratePkcePair:
@@ -57,29 +57,19 @@ class TestGeneratePkcePair:
                 generate_pkce_pair(length=l)
 
     def test_length_default(self):
-        pair = generate_pkce_pair()
-        expected_challenge = sha256_b64url(pair["code_verifier"])
+        code_verifier, code_challenge = generate_pkce_pair()
+        expected_challenge = sha256_b64url(code_verifier)
 
-        assert len(pair["code_verifier"]) == 43
-        assert (
-            re.fullmatch(verifier_challenge_pattern, pair["code_verifier"]) is not None
-        )
-        assert (
-            re.fullmatch(verifier_challenge_pattern, pair["code_challenge"]) is not None
-        )
-        assert pair["code_challenge"] == expected_challenge
+        assert len(code_verifier) == 43
+        assert re.fullmatch(verifier_challenge_pattern, code_verifier) is not None
+        assert re.fullmatch(verifier_challenge_pattern, code_challenge) is not None
+        assert code_challenge == expected_challenge
 
     def test_all_lengths(self):
         for l in range(43, 129):
-            pair = generate_pkce_pair(length=l)
-            expected_challenge = sha256_b64url(pair["code_verifier"])
-            assert len(pair["code_verifier"]) == l
-            assert (
-                re.fullmatch(verifier_challenge_pattern, pair["code_verifier"])
-                is not None
-            )
-            assert (
-                re.fullmatch(verifier_challenge_pattern, pair["code_challenge"])
-                is not None
-            )
-            assert pair["code_challenge"] == expected_challenge
+            code_verifier, code_challenge = generate_pkce_pair(length=l)
+            expected_challenge = sha256_b64url(code_verifier)
+            assert len(code_verifier) == l
+            assert re.fullmatch(verifier_challenge_pattern, code_verifier) is not None
+            assert re.fullmatch(verifier_challenge_pattern, code_challenge) is not None
+            assert code_challenge == expected_challenge

--- a/tests/mocks/constants.py
+++ b/tests/mocks/constants.py
@@ -1,5 +1,5 @@
 import json
-from typing import TypedDict
+from typing import NamedTuple
 import os
 
 mock_dir = os.path.dirname(__file__)
@@ -18,7 +18,7 @@ mock_jwks_alternate = json.load(mock_alternate_jwks_file)
 hostname = "https://id.sgid.com"
 
 
-class MockConstants(TypedDict):
+class MockConstants(NamedTuple):
     server: dict[str, str]
     client: dict[str, str]
     data: dict[str, any]
@@ -27,8 +27,8 @@ class MockConstants(TypedDict):
 API_VERSION = 2
 
 
-MOCK_CONSTANTS: MockConstants = {
-    "server": {
+MOCK_CONSTANTS = MockConstants(
+    server={
         # private_key and public_jwks are a matching pair
         "private_key": mock_private_key_pkcs1.read(),
         "public_jwks": mock_jwks,
@@ -40,7 +40,7 @@ MOCK_CONSTANTS: MockConstants = {
         "userinfo_endpoint": f"{hostname}/v{API_VERSION}/oauth/userinfo",
         "jwks_endpoint": f"{hostname}/v{API_VERSION}/.well-known/jwks.json",
     },
-    "client": {
+    client={
         "client_id": "mockClientId",
         "client_secret": "mockClientSecret",
         "redirect_uri": "https://sgid.com/callback",
@@ -48,7 +48,7 @@ MOCK_CONSTANTS: MockConstants = {
         "private_key": mock_client_keys["privateKey"],
         "private_key_pkcs8": mock_private_key_pkcs8.read(),
     },
-    "data": {
+    data={
         "block_key": {
             "kty": "oct",
             "alg": "A128GCM",
@@ -63,7 +63,7 @@ MOCK_CONSTANTS: MockConstants = {
         "code_verifier": "bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S",
         "code_challenge": "zaqUHoBV3rnhBF2g0Gkz1qkpEZXHqi2OrPK1DqRi-Lk",
     },
-}
+)
 
 mock_client_keys_file.close()
 mock_private_key_pkcs1.close()

--- a/tests/mocks/helpers.py
+++ b/tests/mocks/helpers.py
@@ -13,11 +13,11 @@ from sgid_client.SgidClient import SgidClient
 
 def get_client(delete_args: List[str] = [], **kwargs):
     args = {
-        "client_id": MOCK_CONSTANTS["client"]["client_id"],
-        "client_secret": MOCK_CONSTANTS["client"]["client_secret"],
-        "private_key": MOCK_CONSTANTS["client"]["private_key"],
-        "redirect_uri": MOCK_CONSTANTS["client"]["redirect_uri"],
-        "hostname": MOCK_CONSTANTS["server"]["hostname"],
+        "client_id": MOCK_CONSTANTS.client["client_id"],
+        "client_secret": MOCK_CONSTANTS.client["client_secret"],
+        "private_key": MOCK_CONSTANTS.client["private_key"],
+        "redirect_uri": MOCK_CONSTANTS.client["redirect_uri"],
+        "hostname": MOCK_CONSTANTS.server["hostname"],
     }
     for delete_arg in delete_args:
         del args[delete_arg]
@@ -27,14 +27,14 @@ def get_client(delete_args: List[str] = [], **kwargs):
 
 def create_id_token(
     nonce=None,
-    iss=MOCK_CONSTANTS["server"]["hostname"] + "/v2",
-    sub=MOCK_CONSTANTS["data"]["sub"],
-    aud=MOCK_CONSTANTS["client"]["client_id"],
+    iss=MOCK_CONSTANTS.server["hostname"] + "/v2",
+    sub=MOCK_CONSTANTS.data["sub"],
+    aud=MOCK_CONSTANTS.client["client_id"],
     exp=math.ceil(datetime.now().timestamp() + 10),
     iat=math.ceil(datetime.now().timestamp()),
     header={"alg": "RS256"},
     delete_keys=[],
-    private_key=MOCK_CONSTANTS["server"]["private_key"],
+    private_key=MOCK_CONSTANTS.server["private_key"],
 ) -> str:
     private_key_pkcs8 = RSA.import_key(extern_key=private_key).export_key(pkcs=8)
     private_key_jwk = jwk.JWK.from_pem(private_key_pkcs8)
@@ -61,17 +61,17 @@ def make_base64url_json(content: dict) -> str:
 
 
 def get_jwks_response(
-    url=f"{MOCK_CONSTANTS['server']['hostname']}/v2/.well-known/jwks.json",
-    json=MOCK_CONSTANTS["server"]["public_jwks"],
+    url=f"{MOCK_CONSTANTS.server['hostname']}/v2/.well-known/jwks.json",
+    json=MOCK_CONSTANTS.server["public_jwks"],
 ):
     return responses.Response(method="GET", url=url, json=json)
 
 
 def generate_encrypted_block_key():
     encryption_key = jwk.JWK.from_pem(
-        MOCK_CONSTANTS["client"]["public_key"].encode("utf-8")
+        MOCK_CONSTANTS.client["public_key"].encode("utf-8")
     )
-    payload = json.dumps(MOCK_CONSTANTS["data"]["block_key"])
+    payload = json.dumps(MOCK_CONSTANTS.data["block_key"])
     encrypted = jwe.JWE(
         plaintext=payload,
         protected=json.dumps({"alg": "RSA-OAEP-256", "enc": "A256GCM"}),
@@ -82,8 +82,8 @@ def generate_encrypted_block_key():
 
 def generate_user_info():
     result = {}
-    encryption_key = jwk.JWK.from_json(json.dumps(MOCK_CONSTANTS["data"]["block_key"]))
-    to_encrypt: dict[str, str] = MOCK_CONSTANTS["data"]["userinfo"]
+    encryption_key = jwk.JWK.from_json(json.dumps(MOCK_CONSTANTS.data["block_key"]))
+    to_encrypt: dict[str, str] = MOCK_CONSTANTS.data["userinfo"]
     for k, v in to_encrypt.items():
         encrypted = jwe.JWE(
             plaintext=v, protected=json.dumps({"alg": "A128GCMKW", "enc": "A128GCM"})


### PR DESCRIPTION
## Problem

`TypedDict` is a mutable data structure, and therefore not suitable as a return type for `SgidClient`'s methods. `NamedTuple` is much more appropriate since:
1. It is immutable
2. It provides type hints just like `TypedDict`
3. It is more easily destructured than `TypedDict`

## Solution

Change return types of exported functions to use `NamedTuple` instead of `TypedDict`. Moreover, replace other instances of `TypedDict` with `NamedTuple` for consistency, e.g. in `Errors` object.