### PR TITLE
docs: add homepage and documentation links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 description = "The official Python SDK for sgID"
 authors = ["Open Government Products"]
 readme = "README.md"
+homepage = "https://id.gov.sg"
+documentation = "https://docs.id.gov.sg"
 license = "MIT"
 packages = [{include = "sgid_client"}]
 repository = "https://github.com/opengovsg/sgid-client-python"


### PR DESCRIPTION
Adds repo links so that they appear in in the PyPI sidebar:
<img width="304" alt="Screenshot 2023-05-23 at 4 01 57 PM" src="https://github.com/opengovsg/sgid-client-python/assets/29480346/04a98aee-ae22-45ac-9dc8-48379dbb29e5">
