### PR TITLE
feat: handle array data values

### DIFF
--- a/sgid_client/SgidClient.py
+++ b/sgid_client/SgidClient.py
@@ -8,7 +8,7 @@ from .decrypt_data import decrypt_data
 from .error import Errors, get_network_error_message, get_www_authenticate_error_message
 from .util import (
     convert_to_pkcs8,
-    is_string_wrapped_in_square_brackets,
+    is_stringified_array_or_object_string,
     safe_json_parse
 )
 
@@ -232,6 +232,6 @@ class SgidClient:
             The parsed data value. If the input is a string, then a string is returned. If a
             stringified array or object is passed in, then an array or object is returned respectively.
         """
-        if (is_string_wrapped_in_square_brackets(dataValue)):
+        if (is_stringified_array_or_object_string(dataValue)):
             return safe_json_parse(dataValue)
         return dataValue

--- a/sgid_client/SgidClient.py
+++ b/sgid_client/SgidClient.py
@@ -6,7 +6,11 @@ from .validation import validate_access_token, validate_id_token
 from .IdTokenVerifier import IdTokenVerifier
 from .decrypt_data import decrypt_data
 from .error import Errors, get_network_error_message, get_www_authenticate_error_message
-from .util import convert_to_pkcs8
+from .util import (
+    convert_to_pkcs8,
+    is_string_wrapped_in_square_brackets,
+    safe_json_parse
+)
 
 API_VERSION = 2
 SGID_RESPONSE_TYPE = "code"
@@ -216,3 +220,18 @@ class SgidClient:
             private_key=self.private_key,
         )
         return UserInfoReturn(sub=res_body["sub"], data=decrypted_data)
+
+
+    def parseData(self, dataValue: str) -> dict | list | str:
+        """Parses sgID user data
+
+        Args:
+            dataValue (str): A value from the `data` object returned from the `userinfo` method.
+
+        Returns:
+            The parsed data value. If the input is a string, then a string is returned. If a
+            stringified array or object is passed in, then an array or object is returned respectively.
+        """
+        if (is_string_wrapped_in_square_brackets(dataValue)):
+            return safe_json_parse(dataValue)
+        return dataValue

--- a/sgid_client/SgidClient.py
+++ b/sgid_client/SgidClient.py
@@ -8,7 +8,7 @@ from .decrypt_data import decrypt_data
 from .error import Errors, get_network_error_message, get_www_authenticate_error_message
 from .util import (
     convert_to_pkcs8,
-    is_stringified_array_or_object_string,
+    is_stringified_array_or_object,
     safe_json_parse
 )
 
@@ -232,6 +232,6 @@ class SgidClient:
             The parsed data value. If the input is a string, then a string is returned. If a
             stringified array or object is passed in, then an array or object is returned respectively.
         """
-        if (is_stringified_array_or_object_string(dataValue)):
+        if (is_stringified_array_or_object(dataValue)):
             return safe_json_parse(dataValue)
         return dataValue

--- a/sgid_client/decrypt_data.py
+++ b/sgid_client/decrypt_data.py
@@ -1,9 +1,5 @@
 from jwcrypto import jwk, jwe
 from .error import Errors
-from .util import (
-    is_string_wrapped_in_square_brackets,
-    safe_json_parse
-)
 
 def decrypt_data(encrypted_key: str, encrypted_data: dict, private_key: str):
     try:
@@ -31,12 +27,7 @@ def decrypt_data(encrypted_key: str, encrypted_data: dict, private_key: str):
         for field in encrypted_data:
             # Decrypt encrypted_data[field] to get actual_data
             jwe_data.deserialize(encrypted_data[field], key=block_key)
-
-            decrypted_value = jwe_data.payload.decode("ascii")
-            if (is_string_wrapped_in_square_brackets(decrypted_value)):
-                data_dict[field] = safe_json_parse(decrypted_value)
-            else:
-                data_dict[field] = decrypted_value
+            data_dict[field] = jwe_data.payload.decode("ascii")
     except Exception as exc:
         raise Exception(Errors.USERINFO_DATA_DECRYPT_FAILED) from exc
 

--- a/sgid_client/decrypt_data.py
+++ b/sgid_client/decrypt_data.py
@@ -1,6 +1,9 @@
 from jwcrypto import jwk, jwe
 from .error import Errors
-
+from .util import (
+    is_string_wrapped_in_square_brackets,
+    safe_json_parse
+)
 
 def decrypt_data(encrypted_key: str, encrypted_data: dict, private_key: str):
     try:
@@ -28,7 +31,12 @@ def decrypt_data(encrypted_key: str, encrypted_data: dict, private_key: str):
         for field in encrypted_data:
             # Decrypt encrypted_data[field] to get actual_data
             jwe_data.deserialize(encrypted_data[field], key=block_key)
-            data_dict[field] = jwe_data.payload.decode("ascii")
+
+            decrypted_value = jwe_data.payload.decode("ascii")
+            if (is_string_wrapped_in_square_brackets(decrypted_value)):
+                data_dict[field] = safe_json_parse(decrypted_value)
+            else:
+                data_dict[field] = decrypted_value
     except Exception as exc:
         raise Exception(Errors.USERINFO_DATA_DECRYPT_FAILED) from exc
 

--- a/sgid_client/util.py
+++ b/sgid_client/util.py
@@ -22,7 +22,7 @@ def convert_to_pkcs8(private_key: str) -> str:
     except Exception as exc:
         raise Exception(Errors.PRIVATE_KEY_IMPORT) from exc
 
-def is_stringified_array_or_object_string(possible_array_or_object_string: str) -> bool:
+def is_stringified_array_or_object(possible_array_or_object_string: str) -> bool:
     """Checks whether a string starts and ends with square brackets or starts and ends with curly brackets.
 
     Args:

--- a/sgid_client/util.py
+++ b/sgid_client/util.py
@@ -22,16 +22,16 @@ def convert_to_pkcs8(private_key: str) -> str:
     except Exception as exc:
         raise Exception(Errors.PRIVATE_KEY_IMPORT) from exc
 
-def is_string_wrapped_in_square_brackets(possible_array_string: str) -> bool:
-    """Checks whether a string starts and ends with square brackets.
+def is_stringified_array_or_object_string(possible_array_or_object_string: str) -> bool:
+    """Checks whether a string starts and ends with square brackets or starts and ends with curly brackets.
 
     Args:
-        possible_array_string (str): A string that might or might not be a stringified array.
+        possible_array_or_object_string (str): A string that might or might not be a stringified array.
 
     Returns:
         bool: either true or false
     """
-    return possible_array_string[0] == '[' and possible_array_string[len(possible_array_string)-1] == ']'
+    return (possible_array_or_object_string[0] == '[' and possible_array_or_object_string[len(possible_array_or_object_string)-1] == ']') or (possible_array_or_object_string[0] == '[' and possible_array_or_object_string[len(possible_array_or_object_string)-1] == ']')
 
 def safe_json_parse(json_string: str) -> dict | list | str:
     """Safely parses a stringified JSON object or array.

--- a/sgid_client/util.py
+++ b/sgid_client/util.py
@@ -1,4 +1,5 @@
 from Crypto.PublicKey import RSA
+import json
 
 from sgid_client.error import Errors
 
@@ -20,3 +21,28 @@ def convert_to_pkcs8(private_key: str) -> str:
         return imported.export_key(pkcs=8).decode("ascii")
     except Exception as exc:
         raise Exception(Errors.PRIVATE_KEY_IMPORT) from exc
+
+def is_string_wrapped_in_square_brackets(possible_array_string: str) -> bool:
+    """Checks whether a string starts and ends with square brackets.
+
+    Args:
+        possible_array_string (str): A string that might or might not be a stringified array.
+
+    Returns:
+        bool: either true or false
+    """
+    return possible_array_string[0] == '[' and possible_array_string[len(possible_array_string)-1] == ']'
+
+def safe_json_parse(json_string: str) -> dict | list | str:
+    """Safely parses a stringified JSON object or array.
+
+    Args:
+        json_string (str): A stringified JSON object or array.
+
+    Returns:
+        dict | list | str: The parsed JSON object or array, or the original string if parsing fails.
+    """
+    try:
+        return json.loads(json_string)
+    except Exception:
+        return json_string

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,7 +1,7 @@
 import pytest
 import json
 from sgid_client.util import (
-    is_stringified_array_or_object_string,
+    is_stringified_array_or_object,
     safe_json_parse
 )
 
@@ -14,12 +14,12 @@ exampleString = 'hello world'
 
 class TestIsStringWrappedInSquareBrackets:
     def test_correct_identification_of_input(self):
-        assert is_stringified_array_or_object_string(exampleStringifiedArray) == True
-        assert is_stringified_array_or_object_string(corruptedStringifiedArray) == True
+        assert is_stringified_array_or_object(exampleStringifiedArray) == True
+        assert is_stringified_array_or_object(corruptedStringifiedArray) == True
 
     def test_correct_rejection_of_input(self):
-        assert is_stringified_array_or_object_string(exampleStringifiedObject) == False
-        assert is_stringified_array_or_object_string(exampleString) == False
+        assert is_stringified_array_or_object(exampleStringifiedObject) == False
+        assert is_stringified_array_or_object(exampleString) == False
 
 class TestSafeJsonParse:
     def test_correct_parsing_of_json(self):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,7 +1,7 @@
 import pytest
 import json
 from sgid_client.util import (
-    is_string_wrapped_in_square_brackets,
+    is_stringified_array_or_object_string,
     safe_json_parse
 )
 
@@ -14,12 +14,12 @@ exampleString = 'hello world'
 
 class TestIsStringWrappedInSquareBrackets:
     def test_correct_identification_of_input(self):
-        assert is_string_wrapped_in_square_brackets(exampleStringifiedArray) == True
-        assert is_string_wrapped_in_square_brackets(corruptedStringifiedArray) == True
+        assert is_stringified_array_or_object_string(exampleStringifiedArray) == True
+        assert is_stringified_array_or_object_string(corruptedStringifiedArray) == True
 
     def test_correct_rejection_of_input(self):
-        assert is_string_wrapped_in_square_brackets(exampleStringifiedObject) == False
-        assert is_string_wrapped_in_square_brackets(exampleString) == False
+        assert is_stringified_array_or_object_string(exampleStringifiedObject) == False
+        assert is_stringified_array_or_object_string(exampleString) == False
 
 class TestSafeJsonParse:
     def test_correct_parsing_of_json(self):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,31 @@
+import pytest
+import json
+from sgid_client.util import (
+    is_string_wrapped_in_square_brackets,
+    safe_json_parse
+)
+
+exampleArray = ['a', 'b', 'c']
+exampleStringifiedArray = json.dumps(exampleArray)
+corruptedStringifiedArray = '["a", ]]]]'
+exampleObject = { "a": 'b' }
+exampleStringifiedObject = json.dumps(exampleObject)
+exampleString = 'hello world'
+
+class TestIsStringWrappedInSquareBrackets:
+    def test_correct_identification_of_input(self):
+        assert is_string_wrapped_in_square_brackets(exampleStringifiedArray) == True
+        assert is_string_wrapped_in_square_brackets(corruptedStringifiedArray) == True
+
+    def test_correct_rejection_of_input(self):
+        assert is_string_wrapped_in_square_brackets(exampleStringifiedObject) == False
+        assert is_string_wrapped_in_square_brackets(exampleString) == False
+
+class TestSafeJsonParse:
+    def test_correct_parsing_of_json(self):
+        assert safe_json_parse(exampleStringifiedArray) == exampleArray
+        assert safe_json_parse(exampleStringifiedObject) == exampleObject
+    
+    def test_return_original_json_string_for_invalid_json(self):
+        assert safe_json_parse(corruptedStringifiedArray) == corruptedStringifiedArray
+        assert safe_json_parse(exampleString) == exampleString


### PR DESCRIPTION
## Problem
When we introduce POCDEX as a data source, it will return an array of public officer profiles associated with the NRIC / FIN provided. However, sgID cannot currently process array data values because of how data is stored on the mobile application - for Android the data is stored as a key-value map (so the value needs to be a string) and for iOS, the data is stored in binary form. Therefore, the data value for array fields need to be stored as JSON strings.

## Solution
This PR mitigates this problem by automatically parsing JSON stringified arrays when the SDK decrypts the data. It does so by detecting whether the data string is wrapped in square brackets. Then it performs a safe JSON parse so that if the data is successfully parsed, an array object is returned, and if not, the original string is returned.


## Tests
I created new unit tests for the util functions introduced in this PR.