### PR TITLE
feat: expose ID token

### DIFF
--- a/sgid_client/error.py
+++ b/sgid_client/error.py
@@ -7,6 +7,7 @@ from requests import Response
 class SgidClientError(NamedTuple):
     MISSING_REDIRECT_URI: str
     TOKEN_ENDPOINT_FAILED: str
+    ID_TOKEN_INVALID: str
     ID_TOKEN_MALFORMED: str
     ID_TOKEN_HEADER_PAYLOAD_MALFORMED: str
     ID_TOKEN_WRONG_SIGNING_ALG: str
@@ -33,6 +34,7 @@ class SgidClientError(NamedTuple):
 Errors = SgidClientError(
     MISSING_REDIRECT_URI="No redirect URI registered with this client. You must either specify a valid redirect URI in the SgidClient constructor, or pass it to the authorization_url and callback functions.",
     TOKEN_ENDPOINT_FAILED="sgID responded with an error at the token endpoint",
+    ID_TOKEN_INVALID="sgID token endpoint did not return a valid ID token. Expected a non-empty string.",
     ID_TOKEN_MALFORMED="sgID server returned a malformed ID token which did not contain the expected components (header, payload, signature)",
     ID_TOKEN_HEADER_PAYLOAD_MALFORMED="ID token header or payload was malformed",
     ID_TOKEN_WRONG_SIGNING_ALG="Unexpected signing algorithm used for ID token",

--- a/sgid_client/validation.py
+++ b/sgid_client/validation.py
@@ -22,6 +22,9 @@ def validate_id_token(
     nonce: str | None,
     verifier: IdTokenVerifier.IdTokenVerifier,
 ) -> str:
+    if type(id_token) is not str or id_token == "":
+        raise Exception(Errors.ID_TOKEN_INVALID)
+
     id_token_components = id_token.split(".")
     if len(id_token_components) != 3:
         raise Exception(Errors.ID_TOKEN_MALFORMED)


### PR DESCRIPTION
## Overview

This PR does 2 things:
1. Expose the id token as part of the callback() method 
2. Perform validation on the id token in a manner consistent across SDKs

### 1. Expose the ID token as part of the `callback()` method

Currently, we only expose the `sub` and access token after performing all the requisite checks on the ID token. But the id token is useful because it acts as proof that the user has been authenticated by sgID. Some relying parties want to store
the ID token as part of their audit trail. This is why we're exposing the ID token here.

### 2. Perform validation on the id token in a manner consistent across SDKs

Validation is done according to the SDK implementation strategy here: https://www.notion.so/opengov/SDK-implementation-requirements-1f9b7cbd2bd4406b85d6645fe3e365dd 


## Tests

- Tested locally that the `idToken` is received with [sgid-demo-frontend-spa](https://github.com/opengovsg/sgid-demo-frontend-spa) and the Flask example in this repo.
- Added unit tests
