### PR TITLE
Potential fix for code scanning alert no. 1: Failure to use secure cookies

### DIFF
--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -57,7 +57,7 @@ def get_auth_url():
         "code_verifier": code_verifier,
     }
     res = make_response({"url": url})
-    res.set_cookie(SESSION_COOKIE_NAME, session_id, httponly=True)
+    res.set_cookie(SESSION_COOKIE_NAME, session_id, httponly=True, secure=True, samesite='Lax')
     return res
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/opengovsg/sgid-client-python/security/code-scanning/1](https://github.com/opengovsg/sgid-client-python/security/code-scanning/1)

To fix the issue, the `secure` attribute should be explicitly set to `True` when calling `set_cookie`. This ensures that the cookie is only transmitted over HTTPS connections. Additionally, it is a good practice to set the `samesite` attribute to `'Lax'` or `'Strict'` to mitigate CSRF attacks. These changes will enhance the security of the session cookie.

The fix involves modifying the `set_cookie` call on line 60 to include `secure=True` and `samesite='Lax'`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
